### PR TITLE
Kotlin finder generation

### DIFF
--- a/src/main/java/io/ebean/typequery/generator/write/KotlinLangAdapter.java
+++ b/src/main/java/io/ebean/typequery/generator/write/KotlinLangAdapter.java
@@ -127,12 +127,13 @@ public class KotlinLangAdapter implements LangAdapter {
     writer.append("open class ").append("").append(shortName).append("Finder")
       .append(" : Finder<").append(idTypeShortName).append(", ")
       .append(shortName).append(">(").append(shortName).append("::class.java)")
+      .append(" {")
       .append(NEWLINE);
   }
 
   @Override
   public void finderClassEnd(FileWriter writer) {
-    // do nothing
+    writer.append("}").append(NEWLINE);
   }
 
   @Override


### PR DESCRIPTION
I found a problem in generating the class finder.
The keys "{" and "}" of the class are missing.
So I'm following this little code change.